### PR TITLE
added ability to drop units on toString

### DIFF
--- a/src/quantities.js
+++ b/src/quantities.js
@@ -773,7 +773,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
      *
      * @returns {string} reparseable quantity as string
      */
-    toString: function(targetUnitsOrMaxDecimalsOrPrec, maxDecimals) {
+    toString: function(targetUnitsOrMaxDecimalsOrPrec, maxDecimals, onlyNumber) {
       var targetUnits;
       if(typeof targetUnitsOrMaxDecimalsOrPrec === "number") {
         targetUnits = this.units();
@@ -783,14 +783,18 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
         targetUnits = targetUnitsOrMaxDecimalsOrPrec;
       }
       else if(targetUnitsOrMaxDecimalsOrPrec instanceof Qty) {
-        return this.toPrec(targetUnitsOrMaxDecimalsOrPrec).toString(maxDecimals);
+        if (onlyNumber) {
+            return this.toPrec(targetUnitsOrMaxDecimalsOrPrec).toString(maxDecimals).split(' ')[0];
+        } else {
+            return this.toPrec(targetUnitsOrMaxDecimalsOrPrec).toString(maxDecimals);
+        }
       }
 
       var out = this.to(targetUnits);
 
       var outScalar = maxDecimals !== undefined ? round(out.scalar, maxDecimals) : out.scalar;
       out = (outScalar + " " + out.units()).trim();
-      return out;
+      return (onlyNumber) ? outScalar : out;
     },
 
     // Compare two Qty objects. Throws an exception if they are not of compatible types.


### PR DESCRIPTION
I have been working js quantities into an application I am developing and ran into wanting being able to use toString to return only the scalar and not the number. My specific use case is to convert it to a different unit and assign a precision (in my case of 1 position). I don't want the unit text though (using degree symbol).

I went ahead and added another parameter for the toString number which if left out should default to failing the false check. I have not written any tests, but would be open to writing some if it seems that my proposed addition would get merged in.

Hopefully I am going about this right, haven't done very many pull requests so far.
