### PR TITLE
Prefix handling updates from olbrich/ruby-units#98

### DIFF
--- a/spec/quantitiesSpec.js
+++ b/spec/quantitiesSpec.js
@@ -388,6 +388,9 @@ describe("js-quantities", function() {
 
       expect(qty.to("cm3")).toBe(qty);
       expect(qty.to("cm^3")).toBe(qty);
+
+      qty = new Qty("123 mcg");
+      expect(qty.to("ug")).toBe(qty);
     });
 
     it("should be cached", function() {

--- a/src/quantities.js
+++ b/src/quantities.js
@@ -52,7 +52,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
     "<deci>"  :  [["d","Deci","deci"], 1e-1, "prefix"],
     "<centi>"  : [["c","Centi","centi"], 1e-2, "prefix"],
     "<milli>" :  [["m","Milli","milli"], 1e-3, "prefix"],
-    "<micro>"  : [["u","Micro","micro"], 1e-6, "prefix"],
+    "<micro>"  : [["u","Micro","mc","micro"], 1e-6, "prefix"],
     "<nano>"  :  [["n","Nano","nano"], 1e-9, "prefix"],
     "<pico>"  :  [["p","Pico","pico"], 1e-12, "prefix"],
     "<femto>" :  [["f","Femto","femto"], 1e-15, "prefix"],


### PR DESCRIPTION
1. Throw "Unit not recognized" error on invalid prefixes (such as "mmm").
2. Add "mc" as alternative prefix for "micro" (apparently used in medical abbreviations such as mcg -- microgram).

These changes do not appear to break any existing unit tests.

Added new unit tests for the new functionality.

See: https://github.com/olbrich/ruby-units/pull/98
