### PR TITLE
Fix link to ruby-units

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/gentooboontoo/js-quantities.png)](https://travis-ci.org/gentooboontoo/js-quantities)
 
 JS-quantities is originally a JavaScript port of Kevin Olbrich's library Ruby
-Units (http://ruby-units.rubyforge.org/ruby-units).
+Units (http://github.com/olbrich/ruby-units).
 
 The library aims to simplify the handling of units for scientific calculations
 involving quantities.


### PR DESCRIPTION
Rubyforge is dead, long live... GitHub!

> At 7:03 AM - 10 Nov 2013 Evan Phoenix, in a [tweet](https://twitter.com/evanphx/status/399552820380053505) linked from the https://rubyforge.org/, has announced that RubyForge will be shutting down on May 15 2014, and that users should migrate their data from RubyForge before that date. No explanation was given at that time. 

(from [Wikipedia](http://en.wikipedia.org/wiki/RubyForge))
