### PR TITLE
Use international standard symbol for gradian angle unit

### DIFF
--- a/src/quantities.js
+++ b/src/quantities.js
@@ -217,7 +217,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
     /* angle */
     "<radian>" :[["rad","radian","radians"], 1.0, "angle", ["<radian>"]],
     "<degree>" :[["deg","degree","degrees"], Math.PI / 180.0, "angle", ["<radian>"]],
-    "<grad>"   :[["gon","grad","gradian","grads"], Math.PI / 200.0, "angle", ["<radian>"]],
+    "<gradian>"   :[["gon","grad","gradian","grads"], Math.PI / 200.0, "angle", ["<radian>"]],
     "<steradian>"  : [["sr","steradian","steradians"], 1.0, "solid_angle", ["<steradian>"]],
 
     /* rotation */


### PR DESCRIPTION
Since ISO 31-1, superseded by [ISO 80000-3:2006](http://en.wikipedia.org/wiki/ISO_80000-3), the international standard symbol for grandian angles is "gon" ([Gradian - history](http://en.wikipedia.org/wiki/Gradian#History)). 

Also confirmed by The International System of Units (Si brochure), 8th edition, 2006, BIPM. ([PDF](http://www.bipm.org/utils/common/pdf/si_brochure_8.pdf) - p. 35, 124)

This pull request aims to update js-quantities for those who dare to use this forgotten french unit :smiley:  
