### PR TITLE
Expose constants

### DIFF
--- a/spec/quantitiesSpec.js
+++ b/spec/quantitiesSpec.js
@@ -1062,4 +1062,12 @@ describe('js-quantities', function() {
     });
   });
 
+  describe("Qty.constants", function() {
+    ['KINDS', 'UNITS', 'BASE_UNITS', 'SIGNATURE_VECTOR'].forEach(function(type) {
+      it('should expose ' + type, function() {
+        expect(Qty.constants[type]).toBeDefined();
+      });
+    });
+  });
+
 });

--- a/src/quantities.js
+++ b/src/quantities.js
@@ -368,6 +368,17 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
   }
 
   /**
+   * Expose constants
+   */
+  Qty.constants = {
+    KINDS: KINDS,
+    UNITS: UNITS,
+    BASE_UNITS: BASE_UNITS,
+    SIGNATURE_VECTOR: SIGNATURE_VECTOR
+  };
+  
+
+  /**
    * Parses a string as a quantity
    * @param {string} value - quantity as text
    * @throws if value is not a string


### PR DESCRIPTION
Hey Julien,

No functional changes. This exposes some constants that might be handy for libraries/apps using `js-quantities`.

Personally, I am using `KINDS` to assert that an untrusted user value matches the correct quantity type.

Please update in npm too :)