### PR TITLE
Support temperature symbols 

### DIFF
--- a/spec/quantitiesSpec.js
+++ b/spec/quantitiesSpec.js
@@ -499,6 +499,33 @@ describe("js-quantities", function() {
         expect(Qty("1 \u2126").eq(Qty("1 ohm"))).toBe(true);
       });
     });
+    
+    describe("K", function() {
+      it("should be accepted as unit for kelvin", function() {
+        // K as kelvin sign
+        expect(Qty("1 \u212A").eq(Qty("1 degK"))).toBe(true);
+      });
+    });
+    
+    describe("°C", function() {
+      it("should be accepted as unit for celsius", function() {
+        // °C as celsius sign
+        expect(Qty("1 \u2103").eq(Qty("1 degC"))).toBe(true);
+        // °C as degree sign followed by C
+        expect(Qty("1 \u00B0C").eq(Qty("1 degC"))).toBe(true);
+        expect(Qty("1 °C").eq(Qty("1 degC"))).toBe(true);
+      });
+    });
+    
+    describe("°F", function() {
+      it("should be accepted as unit for fahrenheit", function() {
+        // °F as fahrenheit sign
+        expect(Qty("1 \u2109").eq(Qty("1 degF"))).toBe(true);
+        // °F as degree sign followed by F
+        expect(Qty("1 \u00B0F").eq(Qty("1 degF"))).toBe(true);
+        expect(Qty("1 °F").eq(Qty("1 degF"))).toBe(true);
+      });
+    });
   });
 
   describe("math", function() {

--- a/src/quantities.js
+++ b/src/quantities.js
@@ -128,9 +128,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
     "<gee>" : [["gee"], 9.80665, "acceleration", ["<meter>"], ["<second>","<second>"]],
 
     /* temperature_difference */
-    "<kelvin>" : [["degK","kelvin"], 1.0, "temperature", ["<kelvin>"]],
-    "<celsius>" : [["degC","celsius","celsius","centigrade"], 1.0, "temperature", ["<kelvin>"]],
-    "<fahrenheit>" : [["degF","fahrenheit"], 5/9, "temperature", ["<kelvin>"]],
+    "<kelvin>" : [["degK","\u212A"/*K as kelvin symbol*/,"kelvin"], 1.0, "temperature", ["<kelvin>"]],
+    "<celsius>" : [["degC","\u2103"/*°C as symbol*/,"\u00B0C"/*°C as degree sign followed by C*/,"celsius","celsius","centigrade"], 1.0, "temperature", ["<kelvin>"]],
+    "<fahrenheit>" : [["degF","\u2109"/*°F as symbol*/,"\u00B0F"/*°F as degree sign followed by F*/,"fahrenheit"], 5/9, "temperature", ["<kelvin>"]],
     "<rankine>" : [["degR","rankine"], 5/9, "temperature", ["<kelvin>"]],
     "<temp-K>"  : [["tempK"], 1.0, "temperature", ["<temp-K>"]],
     "<temp-C>"  : [["tempC"], 1.0, "temperature", ["<temp-K>"]],


### PR DESCRIPTION
Add support for °C, °F, and K (the symbol, not the letter).

http://www.unicode.org/charts/beta/nameslist/n_2100.html