### PR TITLE
Remove duplicates from Qty.getKinds()

### DIFF
--- a/spec/quantitiesSpec.js
+++ b/spec/quantitiesSpec.js
@@ -1218,6 +1218,15 @@ describe("js-quantities", function() {
     it("should return an array of kind names", function() {
       expect(Qty.getKinds()).toContain("resistance");
     });
+    
+    it("should not contain duplicate kind names", function() {
+      var kinds = Qty.getKinds();
+      var map = {};
+      kinds.forEach(function(kind) {
+        map[kind] = 1;
+      });
+      expect(kinds.length).toEqual(Object.keys(map).length);
+    });
   });
 
   describe("non regression tests", function() {

--- a/src/quantities.js
+++ b/src/quantities.js
@@ -480,7 +480,12 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
   Qty.getKinds = function() {
     var knownKinds = Object.keys(KINDS).map(function(knownSignature) {
       return KINDS[knownSignature];
-    }).sort();
+    }).sort().filter(function(kind, index, arr) {
+      if (kind === arr[index-1]) {
+        return false;
+      }
+      return true;
+    });
     return knownKinds;
   };
 


### PR DESCRIPTION
Removed duplicate entries (magnetism, viscosity) from getKinds.