### PR TITLE
Add getUnits and getAliases addresses #48

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Qty.getUnits('currency'); // => [ 'dollar', 'cents' ]
 Qty.getUnits(); // => [ 'acre','Ah','ampere','AMU','angstrom']
 ```
 
+### Alternative names of a unit
+
+```javascript
+Qty.getAliases('m'); // => [ 'm', 'meter', 'meters', 'metre', 'metres' ]
+```
+
 ### Quantity compatibility, kind and various queries
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ Qty.parse('foo') // => null
 Qty.getKinds(); // => Array of names of every well-known kind of units
 ```
 
+### Available units of a particular kind
+
+```javascript
+Qty.getUnits('currency'); // => [ 'dollar', 'cents' ]
+// Or all alphabetically sorted
+Qty.getUnits(); // => [ 'acre','Ah','ampere','AMU','angstrom']
+```
+
 ### Quantity compatibility, kind and various queries
 
 ```javascript

--- a/spec/quantitiesSpec.js
+++ b/spec/quantitiesSpec.js
@@ -1239,6 +1239,18 @@ describe("js-quantities", function() {
     });
   });
 
+  describe("Qty.getUnits", function() {
+    it("should return an array of units of kind", function() {
+      expect(Qty.getUnits("currency")).toContain("dollar");
+    });
+    it("should return an array of all units without arg", function () {
+      expect(Qty.getUnits()).toContain("sievert");
+    });
+    it("should throw unknown kind", function () {
+      expect(function () {Qty.getUnits('bogusKind')}).toThrow("Kind not recognized");
+    });
+  });
+
   describe("information", function() {
     describe("bits and bytes", function() {
       it("should have 'information' as kind", function() {

--- a/spec/quantitiesSpec.js
+++ b/spec/quantitiesSpec.js
@@ -1251,6 +1251,14 @@ describe("js-quantities", function() {
     });
   });
 
+  describe("Qty.getAliases", function() {
+    it("should return array of alternative names for unit", function() {
+      expect(Qty.getAliases("m")).toContain("meter");
+      expect(Qty.getAliases("meter")).toContain("metre");
+      expect(Qty.getAliases("N")).toContain("newton");
+    });
+  });
+
   describe("information", function() {
     describe("bits and bytes", function() {
       it("should have 'information' as kind", function() {

--- a/src/quantities.js
+++ b/src/quantities.js
@@ -524,6 +524,20 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
   };
 
   /**
+   * Returns a list of alternative names for a unit
+   *
+   * @param {string} unit
+   * @returns {string[]} aliases for unit
+   * @throws {QtyError} if unit is unknown
+   */
+  Qty.getAliases = function(unitName) {
+    if (!UNIT_MAP[unitName]) {
+        throw new QtyError('Unit not recognized');
+    }
+    return UNITS[UNIT_MAP[unitName]][0];
+  };
+
+  /**
    * Default formatter
    *
    * @param {number} scalar
@@ -1826,7 +1840,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
       OUTPUT_MAP[unitDef] = definition[0][0];
     }
   }
-
   var PREFIX_REGEX = Object.keys(PREFIX_MAP).sort(function(a, b) {
     return b.length - a.length;
   }).join("|");

--- a/src/quantities.js
+++ b/src/quantities.js
@@ -489,6 +489,41 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
   };
 
   /**
+   * Returns a list of available units of kind
+   *
+   * @param {string} [kind]
+   * @returns {array} names of units
+   * @throws {QtyError} if kind is unknown
+   */
+  Qty.getUnits = function(kind) {
+    var units = [];
+    var unitKeys = Object.keys(UNITS);
+    if (typeof kind === 'undefined') {
+      for(var i = 0; i < unitKeys.length; i++) {
+        if (['', 'prefix'].indexOf(UNITS[unitKeys[i]][2]) == -1) {
+          units.push(unitKeys[i].substr(1, unitKeys[i].length - 2));
+        }
+      }
+    }
+    else if (Qty.getKinds().indexOf(kind) === -1) {
+      throw new QtyError('Kind not recognized');
+    }
+    else {
+      for(var i = 0; i < unitKeys.length; i++) {
+        if (UNITS[unitKeys[i]][2] === kind) {
+          units.push(unitKeys[i].substr(1, unitKeys[i].length - 2));
+        }
+      }
+    }
+
+    return units.sort(function(a, b){
+      if(a.toLowerCase() < b.toLowerCase()) return -1;
+      if(a.toLowerCase() > b.toLowerCase()) return 1;
+      return 0;
+    });
+  };
+
+  /**
    * Default formatter
    *
    * @param {number} scalar
@@ -1791,6 +1826,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
       OUTPUT_MAP[unitDef] = definition[0][0];
     }
   }
+
   var PREFIX_REGEX = Object.keys(PREFIX_MAP).sort(function(a, b) {
     return b.length - a.length;
   }).join("|");


### PR DESCRIPTION
This is one solution to the issue.  In #14 @rage-shadowman had mentioned "Another alternative, if you don't want ambiguous arrays, would be to return only the unit names (ie: for "<liter>" return "liter" -- the name sans the "<>" chars) and a getAliases method to get all the aliases for a named unit (["l", "L", "liter", "liters", "litre", "litres"]) or maybe event all the alternative aliases for a given alias (such that getAlternatives("liter") returns an identical array to getAlternatives("L"))."

I agree the grouped arrays are ambiguous, so I'm using that approach:
```javascript
Qty.getUnits('currency'); // => [ 'dollar', 'cents' ]
Qty.getAliases('m'); // => [ 'm', 'meter', 'meters', 'metre', 'metres' ]
```
So only one name for each unit is returned. 
Also:
```javascript
Qty.getUnits(); // => [ 'acre','Ah','ampere','AMU','angstrom', ...]
```
So getUnits is sorted to make it perfect for feeding choices to the user. (Select box, predictive input)

@gentooboontoo  also mentioned the getAliases method and again i agree, these should be separate functions.  If this goes over well I can make a separate commit for the getPrefixes but I think there are quite a few versions of that that looked great already.  They just are bundled up with these other changes.

Thanks for js-quantities!  It's working out for us.