### PR TITLE
Add new two-argument signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Qty.parse('1 m'); // => 1 meter
 Qty.parse('foo') // => null
 ```
 
+If scalars and their respective units are available programmatically, the two argument signature may be useful:
+
+```javascript
+Qty.parse(124, 'cm'); // => 1.24 meter
+```
+
 ### Available well-known kinds
 
 ```javascript

--- a/spec/quantitiesSpec.js
+++ b/spec/quantitiesSpec.js
@@ -36,6 +36,13 @@ describe("js-quantities", function() {
       expect(qty.denominator).toEqual(["<1>"]);
     });
 
+    it("should create from numbers with explicit units", function() {
+      var qty = Qty(1.5, "m");
+      expect(qty.scalar).toBe(1.5);
+      expect(qty.numerator).toEqual(["<meter>"]);
+      expect(qty.denominator).toEqual(["<1>"]);
+    });
+
     it("temperatures should have base unit in kelvin", function() {
       var qty = Qty("1 tempK").toBase();
       expect(qty.scalar).toBe(1);
@@ -1062,7 +1069,7 @@ describe("js-quantities", function() {
         expect(qty.format("cm", roundingFormatter(2))).toBe("66.67 cm");
 
         var intRoundingFormatter = roundingFormatter(0);
-        qty = Qty("2.8m", intRoundingFormatter);
+        qty = Qty("2.8m");
         expect(qty.format("m", intRoundingFormatter)).toBe("3 m");
         expect(qty.format("cm", intRoundingFormatter)).toBe("280 cm");
         qty = Qty("2.818m");
@@ -1228,7 +1235,7 @@ describe("js-quantities", function() {
     it("should return an array of kind names", function() {
       expect(Qty.getKinds()).toContain("resistance");
     });
-    
+
     it("should not contain duplicate kind names", function() {
       var kinds = Qty.getKinds();
       var map = {};

--- a/src/quantities.js
+++ b/src/quantities.js
@@ -352,11 +352,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
   var baseUnitCache = {};
 
-  function Qty(initValue) {
-    assertValidInitializationValueType(initValue);
+  function Qty(initValue, initUnits) {
+    assertValidInitializationValueType(initValue, initUnits);
 
     if(!(isQty(this))) {
-      return new Qty(initValue);
+      return new Qty(initValue, initUnits);
     }
 
     this.scalar = null;
@@ -370,8 +370,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
       this.scalar = initValue.scalar;
       this.numerator = (initValue.numerator && initValue.numerator.length !== 0)? initValue.numerator : UNITY_ARRAY;
       this.denominator = (initValue.denominator && initValue.denominator.length !== 0)? initValue.denominator : UNITY_ARRAY;
-    }
-    else {
+    } else if (initUnits) {
+      parse.call(this, initUnits);
+      this.scalar *= initValue;
+    } else {
       parse.call(this, initValue);
     }
 
@@ -1805,10 +1807,17 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
    *
    * @throws {QtyError} if initialization value type is not valid
    */
-  function assertValidInitializationValueType(value) {
-    if (!(isString(value) || isNumber(value) || isQty(value) || isDefinitionObject(value))) {
-      throw new QtyError("Only strings, numbers or quantities " +
-                         "accepted as initialization values");
+  function assertValidInitializationValueType(value, units) {
+    if (units) {
+      if (!(isNumber(value) && isString(units))) {
+        throw new QtyError("Only numbers " +
+                           "accepted as initialization values when units are provided explicitly");
+      }
+    } else {
+      if (!(isString(value) || isNumber(value) || isQty(value) || isDefinitionObject(value))) {
+        throw new QtyError("Only strings, numbers or quantities " +
+                           "accepted as initialization values");
+      }
     }
   }
 


### PR DESCRIPTION
I have a use-case where my units and scalars are each available programmatically. This patch adds a convenience constructor to support this usage:

```javascript
// New signature
new Qty(10, "m");
// which is equivalent to
new Qty("10 m"); 
```

:octocat: 
