### PR TITLE
Accept empty string as initialization value

### DIFF
--- a/spec/quantitiesSpec.js
+++ b/spec/quantitiesSpec.js
@@ -219,13 +219,9 @@ describe("js-quantities", function() {
       expect(function() { Qty("mmm"); }).toThrow("Unit not recognized");
     });
 
-    it("should throw error when passing an empty string", function() {
-      expect(
-        function() { Qty(""); }
-      ).toThrow("Unit not recognized");
-      expect(
-        function() { Qty("   "); }
-      ).toThrow("Unit not recognized");
+    it("should accept empty string as unitless 1", function() {
+      expect(Qty("").same(Qty("1"))).toBe(true);
+      expect(Qty("   ").same(Qty("1"))).toBe(true);
     });
 
     it("should throw error when passing a null value", function() {

--- a/src/quantities.js
+++ b/src/quantities.js
@@ -671,9 +671,6 @@ SOFTWARE.
       val = val.toString();
     }
     val = val.trim();
-    if (val.length === 0) {
-      throw new QtyError("Unit not recognized");
-    }
 
     var result = QTY_STRING_REGEX.exec(val);
     if (!result) {


### PR DESCRIPTION
It reverts change from bd6bedc2.

Accepting blank strings is a more logical behavior since:

* Scalarless initialization values are currently accepted (`Qty("m") => 1 m`)
* Unitless initialization values are currently accepted (`Qty("3") => 3`)
* Units of a unitless quantity are an empty string (`Qty("3").units() => ""`)
* `Qty(qtyInstance.units())` is not expected to fail (it currently does
with a unitless quantity)
* It is backward compatible with Ruby Units