### PR TITLE
Rename mass concentration kind to density

### DIFF
--- a/src/quantities.js
+++ b/src/quantities.js
@@ -342,7 +342,7 @@ SOFTWARE.
     "7962": "energy",
     "7979": "viscosity",
     "7961": "force",
-    "7997": "mass_concentration",
+    "7997": "density",
     "8000": "mass",
     "159999": "magnetism",
     "160000": "current",


### PR DESCRIPTION
In english, and in chemistry, "mass concentration" does refer to
`<mass>`/`<volume>` but the term seems to be used only for mixtures.

"Density" in the common scientific language, refers to the volumetric
mass density of a pure substance.

It is unfortunately impossible with the diamensional analysis only to
know the quantity context, but for english native people, "density"
should be better understood.

This explanation could explain why this kind has been renamed in
ruby-units by https://github.com/olbrich/ruby-units/commit/0915620b7815302b50d73c77e4ab34ee5d7612b2.

Sources:
https://en.wikipedia.org/wiki/Density
https://en.wikipedia.org/wiki/Mass_concentration_(chemistry)