### PR TITLE
Update definitions.js: Added volt-ampere(reactive)

### DIFF
--- a/src/quantities/definitions.js
+++ b/src/quantities/definitions.js
@@ -227,6 +227,8 @@ export var UNITS = {
 
   /* power */
   "<watt>"  : [["W","watt","watts"], 1.0, "power", ["<kilogram>","<meter>","<meter>"], ["<second>","<second>","<second>"]],
+  "<volt-ampere>"  : [["VA","V*A"], 1.0, "power", ["<kilogram>","<meter>","<meter>"], ["<second>","<second>","<second>"]],
+  "<volt-ampere reactive>"  : [["var","Var","VAr","VAR"], 1.0, "power", ["<kilogram>","<meter>","<meter>"], ["<second>","<second>","<second>"]],
   "<horsepower>"  :  [["hp","horsepower"], 745.699872, "power", ["<kilogram>","<meter>","<meter>"], ["<second>","<second>","<second>"]],
 
   /* radiation */


### PR DESCRIPTION
Added units:
* `<volt-ampere>`, which is the unit used for the apparent power. Abbreviation: VA (also used: V*A)
* `<volt-ampere reactive>`, which is the unit used for the reactive power. Abbreviation: var (also falsely used: Var, VAr, VAR)