### PR TITLE
deal with prefixes when multiplying or dividing

### DIFF
--- a/spec/quantitiesSpec.js
+++ b/spec/quantitiesSpec.js
@@ -777,6 +777,32 @@ describe("js-quantities", function() {
       expect(result.units()).toBe("");
     });
 
+    it("should multiply quantities and their inverses with prefixes", function() {
+        var qty1 = Qty("3m");
+        var qty2 = Qty("4 1/km");
+        var result = qty1.mul(qty2);
+        expect(result.scalar).toBe(0.012);
+        expect(result.isUnitless()).toBe(true);
+
+        var qty1 = Qty("3 A/km");
+        var qty2 = Qty("4 m");
+        var result = qty1.mul(qty2);
+        expect(result.scalar).toBe(0.012);
+        expect(result.units()).toBe("A");
+
+        var qty1 = Qty("3 1/km2");
+        var qty2 = Qty("4 m");
+        var result = qty1.mul(qty2);
+        expect(result.scalar).toBe(0.012);
+        expect(result.units()).toBe("1/km");
+
+        var qty1 = Qty("4 m");
+        var qty2 = Qty("3 1/km2");
+        var result = qty1.mul(qty2);
+        expect(result.scalar).toBe(0.000012);
+        expect(result.units()).toBe("1/m");
+    });
+
     it("should divide quantities", function() {
       var qty1 = Qty("2.5m");
       var qty2 = Qty("3m");
@@ -838,6 +864,26 @@ describe("js-quantities", function() {
       result = qty3.div(qty1);
       expect(result.scalar).toBe(0.01);
       expect(result.units()).toBe("1/S2");
+    });
+
+    it("should divide quantities and their inverses with prefixes", function() {
+        var qty1 = Qty("3m*A");
+        var qty2 = Qty("4 km");
+        var result = qty1.div(qty2);
+        expect(result.scalar).toBe(0.00075);
+        expect(result.units()).toBe("A");
+
+        qty1 = Qty("3 m");
+        qty2 = Qty("4 km*A");
+        result = qty1.div(qty2);
+        expect(result.scalar).toBe(0.00075);
+        expect(result.units()).toBe("1/A");
+
+        qty1 = Qty("3 m");
+        qty2 = Qty("4 km*cA");
+        result = qty1.div(qty2);
+        expect(result.scalar).toBe(0.00075);
+        expect(result.units()).toBe("1/cA");
     });
 
   });


### PR DESCRIPTION
Aims to fix gentooboontoo/js-quantities#94.

The method to multiply q1 by q2 goes as follows:

* if q1 and q2 are compatible (they have exactly the same signature),
  convert q2 to the same units as q1
* collect together the numerators and denominators of q1 and q2, and
  'clean'
* multiply q1 and q2's scalars together, and return a unit that big with the
  cleaned numerator and denominator

The cleaning code doesn't gather together units of the same kind, but
with different prefixes. I suspect this is deliberate, but it leads to
inconsistencies like `Qty('1 m').div('1 km') = 0.001`, but `Qty('1
m').mul('1 1/km') = 1 m/km`.

This commit changes `cleanTerms` to keep track of the prefix used with
each unit, and accumulate a scaling factor when the same unit is used with a
different prefix. The function returns numerator, denominator, and the
scaling factor.

Following the logic that `km*m` returns a quantity in `km`, and `m*km`
returns a quantity in `m`, the prefix associated with the first occurrence
of each unit encountered is used.