### PR TITLE
Resolve units unrecognized by getAliases

### DIFF
--- a/src/quantities/definitions.js
+++ b/src/quantities/definitions.js
@@ -94,9 +94,9 @@ export var UNITS = {
   "<tablespoon>":  [["tb","tbsp","tbs","tablespoon","tablespoons"], 1.47867648e-5, "volume", ["<meter>","<meter>","<meter>"]],
   "<teaspoon>":  [["tsp","teaspoon","teaspoons"], 4.92892161e-6, "volume", ["<meter>","<meter>","<meter>"]],
   "<bushel>":  [["bu","bsh","bushel","bushels"], 0.035239072, "volume", ["<meter>","<meter>","<meter>"]],
-  "<oilbarrel>":  [["bbl","oil-barrel","oil-barrels"], 0.158987294928, "volume", ["<meter>","<meter>","<meter>"]],
-  "<beerbarrel>":  [["bl","bl-us","beer-barrel","beer-barrels"], 0.1173477658, "volume", ["<meter>","<meter>","<meter>"]],
-  "<beerbarrel-imp>":  [["blimp","bl-imp","beer-barrel-imp","beer-barrels-imp"], 0.16365924, "volume", ["<meter>","<meter>","<meter>"]],
+  "<oilbarrel>":  [["bbl","oilbarrel", "oilbarrels", "oil-barrel","oil-barrels"], 0.158987294928, "volume", ["<meter>","<meter>","<meter>"]],
+  "<beerbarrel>":  [["bl","bl-us","beerbarrel", "beerbarrels", "beer-barrel","beer-barrels"], 0.1173477658, "volume", ["<meter>","<meter>","<meter>"]],
+  "<beerbarrel-imp>":  [["blimp","bl-imp","beerbarrel-imp", "beerbarrels-imp", "beer-barrel-imp","beer-barrels-imp"], 0.16365924, "volume", ["<meter>","<meter>","<meter>"]],
 
   /* speed */
   "<kph>" : [["kph"], 0.277777778, "speed", ["<meter>"], ["<second>"]],


### PR DESCRIPTION
Attempt to resolve https://github.com/gentooboontoo/js-quantities/issues/101 by 
adding original unit names to the list of known aliases for ["beerbarrel", "beerbarrel-imp", "oilbarrel"].