### PR TITLE
test: add a test to verify point/pint compatibility

### DIFF
--- a/spec/quantitiesSpec.js
+++ b/spec/quantitiesSpec.js
@@ -372,6 +372,23 @@ describe("js-quantities", function() {
 
       expect(qty1.isCompatible({})).toBe(false);
     });
+
+    it("should return true for mm and point", function() {
+      // if a pint was parsed before point
+      // point and meter should not become incompatible
+      Qty("1 pint");
+      var point = Qty("1 point");
+      var mm = Qty("1 mm");
+
+      expect(mm.isCompatible(point)).toBe(true);
+    });
+
+    it("should return false for point and pint", function() {
+      var pint = Qty("1 pint");
+      var point = Qty("1 point");
+
+      expect(pint.isCompatible(point)).toBe(false);
+    });
   });
 
   describe("conversion", function() {


### PR DESCRIPTION
Trying to parse the pint unit before the point unit makes the point and meters incompatible.

For some reason, the signature of point and pint always matches and depends on the order they were parsed:

```js
const Qty = require('js-quantities');

const point = new Qty('1point');
const pint = new Qty('1pint');
console.log(pint.signature, point.signature); // -> 1 1
```

```js
const Qty = require('js-quantities');

const pint = new Qty('1pint');
const point = new Qty('1point');
console.log(pint.signature, point.signature); // -> 3 3
```

Linked to https://github.com/gentooboontoo/js-quantities/issues/26, I guess.