### PR TITLE
Fix wrong quantity name for molar_concentration units

### DIFF
--- a/build/quantities.js
+++ b/build/quantities.js
@@ -341,9 +341,9 @@ SOFTWARE.
     /* substance */
     "<mole>"  :  [["mol","mole"], 1.0, "substance", ["<mole>"]],
 
-    /* concentration */
-    "<molar>" : [["M","molar"], 1000, "concentration", ["<mole>"], ["<meter>","<meter>","<meter>"]],
-    "<wtpercent>"  : [["wt%","wtpercent"], 10, "concentration", ["<kilogram>"], ["<meter>","<meter>","<meter>"]],
+    /* molar_concentration */
+    "<molar>" : [["M","molar"], 1000, "molar_concentration", ["<mole>"], ["<meter>","<meter>","<meter>"]],
+    "<wtpercent>"  : [["wt%","wtpercent"], 10, "molar_concentration", ["<kilogram>"], ["<meter>","<meter>","<meter>"]],
 
     /* activity */
     "<katal>" :  [["kat","katal","Katal"], 1.0, "activity", ["<mole>"], ["<second>"]],

--- a/build/quantities.mjs
+++ b/build/quantities.mjs
@@ -335,9 +335,9 @@ var UNITS = {
   /* substance */
   "<mole>"  :  [["mol","mole"], 1.0, "substance", ["<mole>"]],
 
-  /* concentration */
-  "<molar>" : [["M","molar"], 1000, "concentration", ["<mole>"], ["<meter>","<meter>","<meter>"]],
-  "<wtpercent>"  : [["wt%","wtpercent"], 10, "concentration", ["<kilogram>"], ["<meter>","<meter>","<meter>"]],
+  /* molar_concentration */
+  "<molar>" : [["M","molar"], 1000, "molar_concentration", ["<mole>"], ["<meter>","<meter>","<meter>"]],
+  "<wtpercent>"  : [["wt%","wtpercent"], 10, "molar_concentration", ["<kilogram>"], ["<meter>","<meter>","<meter>"]],
 
   /* activity */
   "<katal>" :  [["kat","katal","Katal"], 1.0, "activity", ["<mole>"], ["<second>"]],

--- a/spec/quantitiesSpec.js
+++ b/spec/quantitiesSpec.js
@@ -1458,6 +1458,10 @@ describe("js-quantities", function() {
     it("should return an array of units of kind", function() {
       expect(Qty.getUnits("currency")).toContain("dollar");
     });
+    it("should return correct units for molar_concentration", function() {
+      expect(Qty.getUnits("molar_concentration")).toContain("molar");
+      expect(Qty.getUnits("molar_concentration")).toContain("wtpercent");
+    });
     it("should return an array of all units without arg", function() {
       expect(Qty.getUnits()).toContain("sievert");
     });

--- a/src/quantities/definitions.js
+++ b/src/quantities/definitions.js
@@ -147,9 +147,9 @@ export var UNITS = {
   /* substance */
   "<mole>"  :  [["mol","mole"], 1.0, "substance", ["<mole>"]],
 
-  /* concentration */
-  "<molar>" : [["M","molar"], 1000, "concentration", ["<mole>"], ["<meter>","<meter>","<meter>"]],
-  "<wtpercent>"  : [["wt%","wtpercent"], 10, "concentration", ["<kilogram>"], ["<meter>","<meter>","<meter>"]],
+  /* molar_concentration */
+  "<molar>" : [["M","molar"], 1000, "molar_concentration", ["<mole>"], ["<meter>","<meter>","<meter>"]],
+  "<wtpercent>"  : [["wt%","wtpercent"], 10, "molar_concentration", ["<kilogram>"], ["<meter>","<meter>","<meter>"]],
 
   /* activity */
   "<katal>" :  [["kat","katal","Katal"], 1.0, "activity", ["<mole>"], ["<second>"]],


### PR DESCRIPTION
The concentration units in `definitions.js` had `concentration` as quantity, but only `molar_concentration` exists as kind.