### PR TITLE
Add hundred weight mass unit definitions

### DIFF
--- a/src/quantities/definitions.js
+++ b/src/quantities/definitions.js
@@ -75,6 +75,8 @@ export var UNITS = {
   "<grain>" : [["grain","grains","gr"], 6.479891e-5, "mass", ["<kilogram>"]],
   "<dram>"  : [["dram","drams","dr"], 0.0017718452, "mass",["<kilogram>"]],
   "<stone>" : [["stone","stones","st"],6.35029318, "mass",["<kilogram>"]],
+  "<hundredweight>" : [["short-hundredweight","us-hundredweight","cwt","cental"],45.359237, "mass",["<kilogram>"]],
+  "<long-hundredweight>" : [["imperial-hundredweight","uk-hundredweight","long-cwt"],50.80234544, "mass",["<kilogram>"]],
 
   /* area */
   "<hectare>":[["hectare"], 10000, "area", ["<meter>","<meter>"]],


### PR DESCRIPTION
This adds hundredweight units to js-quantities.

These are weird units, but are used in some specific industries.

* Definitions: https://en.wikipedia.org/wiki/Hundredweight
* Implementation in other unit conversion library (Python Pints): https://github.com/hgrecco/pint/blob/master/pint/default_en.txt#L579