### PR TITLE
format: stop relying on array properties

### DIFF
--- a/build/quantities.js
+++ b/build/quantities.js
@@ -383,7 +383,7 @@ SOFTWARE.
     "<oersted>"  : [["Oe","oersted","oersteds"], 250.0 / Math.PI, "magnetism", ["<ampere>"], ["<meter>"]],
 
     /* energy */
-    "<joule>" :  [["J","joule","Joule","joules"], 1.0, "energy", ["<meter>","<meter>","<kilogram>"], ["<second>","<second>"]],
+    "<joule>" :  [["J","joule","Joule","joules","Joules"], 1.0, "energy", ["<meter>","<meter>","<kilogram>"], ["<second>","<second>"]],
     "<erg>"   :  [["erg","ergs"], 1e-7, "energy", ["<meter>","<meter>","<kilogram>"], ["<second>","<second>"]],
     "<btu>"   :  [["BTU","btu","BTUs"], 1055.056, "energy", ["<meter>","<meter>","<kilogram>"], ["<second>","<second>"]],
     "<calorie>" :  [["cal","calorie","calories"], 4.18400, "energy",["<meter>","<meter>","<kilogram>"], ["<second>","<second>"]],
@@ -460,7 +460,9 @@ SOFTWARE.
     "<dozen>" :  [["doz","dz","dozen"],12.0,"prefix_only", ["<each>"]],
     "<percent>": [["%","percent"], 0.01, "prefix_only", ["<1>"]],
     "<ppm>" :  [["ppm"],1e-6, "prefix_only", ["<1>"]],
-    "<ppt>" :  [["ppt"],1e-9, "prefix_only", ["<1>"]],
+    "<ppb>" :  [["ppb"],1e-9, "prefix_only", ["<1>"]],
+    "<ppt>" :  [["ppt"],1e-12, "prefix_only", ["<1>"]],
+    "<ppq>" :  [["ppq"],1e-15, "prefix_only", ["<1>"]],
     "<gross>" :  [["gr","gross"],144.0, "prefix_only", ["<dozen>","<dozen>"]],
     "<decibel>"  : [["dB","decibel","decibels"], 1.0, "logarithmic", ["<decibel>"]]
   };
@@ -1991,10 +1993,13 @@ SOFTWARE.
   function simplify(units) {
     // this turns ['s','m','s'] into ['s2','m']
 
+    var counters = {};
     var unitCounts = units.reduce(function(acc, unit) {
-      var unitCounter = acc[unit];
+      var unitCounter = counters[unit];
       if (!unitCounter) {
-        acc.push(unitCounter = acc[unit] = [unit, 0]);
+        unitCounter = [unit, 0];
+        counters[unit] = unitCounter;
+        acc.push(unitCounter);
       }
 
       unitCounter[1]++;

--- a/build/quantities.mjs
+++ b/build/quantities.mjs
@@ -377,7 +377,7 @@ var UNITS = {
   "<oersted>"  : [["Oe","oersted","oersteds"], 250.0 / Math.PI, "magnetism", ["<ampere>"], ["<meter>"]],
 
   /* energy */
-  "<joule>" :  [["J","joule","Joule","joules"], 1.0, "energy", ["<meter>","<meter>","<kilogram>"], ["<second>","<second>"]],
+  "<joule>" :  [["J","joule","Joule","joules","Joules"], 1.0, "energy", ["<meter>","<meter>","<kilogram>"], ["<second>","<second>"]],
   "<erg>"   :  [["erg","ergs"], 1e-7, "energy", ["<meter>","<meter>","<kilogram>"], ["<second>","<second>"]],
   "<btu>"   :  [["BTU","btu","BTUs"], 1055.056, "energy", ["<meter>","<meter>","<kilogram>"], ["<second>","<second>"]],
   "<calorie>" :  [["cal","calorie","calories"], 4.18400, "energy",["<meter>","<meter>","<kilogram>"], ["<second>","<second>"]],
@@ -454,7 +454,9 @@ var UNITS = {
   "<dozen>" :  [["doz","dz","dozen"],12.0,"prefix_only", ["<each>"]],
   "<percent>": [["%","percent"], 0.01, "prefix_only", ["<1>"]],
   "<ppm>" :  [["ppm"],1e-6, "prefix_only", ["<1>"]],
-  "<ppt>" :  [["ppt"],1e-9, "prefix_only", ["<1>"]],
+  "<ppb>" :  [["ppb"],1e-9, "prefix_only", ["<1>"]],
+  "<ppt>" :  [["ppt"],1e-12, "prefix_only", ["<1>"]],
+  "<ppq>" :  [["ppq"],1e-15, "prefix_only", ["<1>"]],
   "<gross>" :  [["gr","gross"],144.0, "prefix_only", ["<dozen>","<dozen>"]],
   "<decibel>"  : [["dB","decibel","decibels"], 1.0, "logarithmic", ["<decibel>"]]
 };
@@ -1985,10 +1987,13 @@ function getOutputNames(units) {
 function simplify(units) {
   // this turns ['s','m','s'] into ['s2','m']
 
+  var counters = {};
   var unitCounts = units.reduce(function(acc, unit) {
-    var unitCounter = acc[unit];
+    var unitCounter = counters[unit];
     if (!unitCounter) {
-      acc.push(unitCounter = acc[unit] = [unit, 0]);
+      unitCounter = [unit, 0];
+      counters[unit] = unitCounter;
+      acc.push(unitCounter);
     }
 
     unitCounter[1]++;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "js-quantities",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/spec/quantitiesSpec.js
+++ b/spec/quantitiesSpec.js
@@ -345,6 +345,22 @@ describe("js-quantities", function() {
     });
   });
 
+  describe("initialization with extensions to Array prototype", function() {
+    beforeEach(function() {
+      Array.prototype["min"] = Math.min;
+    });
+
+    afterEach(function() {
+      delete Array.prototype["min"];
+    });
+
+    it("initialization should be agnostic to Array prototype extensions", function() {
+      var qty = Qty("100 gal/min");
+      expect(qty.scalar).toEqual(100);
+      expect(qty.units()).toEqual("gal/min");
+    });
+  });
+
   describe("isCompatible", function() {
     it("should return true with compatible quantities", function() {
       var qty1 = Qty("1 m*kg/s");

--- a/src/quantities/format.js
+++ b/src/quantities/format.js
@@ -183,10 +183,13 @@ function getOutputNames(units) {
 function simplify(units) {
   // this turns ['s','m','s'] into ['s2','m']
 
+  var counters = {};
   var unitCounts = units.reduce(function(acc, unit) {
-    var unitCounter = acc[unit];
+    var unitCounter = counters[unit];
     if (!unitCounter) {
-      acc.push(unitCounter = acc[unit] = [unit, 0]);
+      unitCounter = [unit, 0];
+      counters[unit] = unitCounter;
+      acc.push(unitCounter);
     }
 
     unitCounter[1]++;


### PR DESCRIPTION
There are numerous libraries out there (sugarjs, prototypejs) that extend the `Array` prototype. The `simplify` function in js-quantities relies on setting/checking properties on an array instance, which means that it's incompatible with such libraries. This PR fixes #130, adding compatibility by using a separate object for keeping track of the counters instead of using properties on array instances.